### PR TITLE
ENH: Add RTF features to narratives

### DIFF
--- a/nlg/app/body.html
+++ b/nlg/app/body.html
@@ -98,8 +98,34 @@
         </script>
       </div>
       <div class="col">
-        <div class="border border-primary pl-2 pr-2 bg-light">
-          <p class="text-justify" id="previewspan"></p>
+        <div class="container">
+          <div class="row">
+            <div class="col d-flex justify-content-left bd-highlight">
+              <button id="boldpreview" type="button" class="btn btn-primary"
+                data-toggle="button" aria-pressed="false" autocomplete="off">
+                <i class="fa fa-bold"></i></button>
+              <button id="italicpreview" type="button" class="btn btn-primary"
+                data-toggle="button" aria-pressed="false" autocomplete="off">
+                <i class="fa fa-italic"></i></button>
+              <button id="ulinepreview" type="button" class="btn btn-primary"
+                data-toggle="button" aria-pressed="false" autocomplete="off">
+                <i class="fa fa-underline"></i></button>
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                <label class="btn btn-primary" id="paralabel">
+                  <input type="radio" name="renderstyle" id="parastyle"
+                    autocomplete="off"><i class="fa fa-paragraph"></i>
+                </label>
+                <label class="btn btn-primary" id="listlabel">
+                  <input type="radio" name="renderstyle" id="liststyle"
+                    autocomplete="off"><i class="fa fa-list"></i>
+                </label>
+              </div>
+            </div>
+            <div class="w-100"></div>
+            <div class="col border border-primary pl-2 pr-2 bg-light">
+              <div class="text-justify" id="previewspan"></div>
+            </div>
+          </div>
         </div>
       </div>
       <!-- <div class="col-sm-3">
@@ -211,11 +237,11 @@
   var df = null;
   var args = null;
   var templates = [];
-  var currentEventHandlers = {};
   var currentTemplateIndex = null;
   var currentTokenIndex = null;
   var narrative_name = "";
   var dataset_name = "";
+  // var styleparams = {bold: true, italic: false, underline: false, style: 'para'}
 
   $(document).ready(setInitialConfig)
 
@@ -237,6 +263,11 @@
     $('#embedCodeText').val(getNarrativeEmbedCode())
     $('#embed-modal').modal({show: true})
   })
+  .on('click', '#boldpreview', toggleRenderStyle)
+  .on('click', '#italicpreview', toggleRenderStyle)
+  .on('click', '#ulinepreview', toggleRenderStyle)
+  .on('change', '#parastyle', toggleRenderStyle)
+  .on('change', '#liststyle', toggleRenderStyle)
 
   $("#textbox").attr('cols', 119)
   $("#edit-template").attr('cols', 69).attr('rows', 10)

--- a/nlg/app/gramex.yaml
+++ b/nlg/app/gramex.yaml
@@ -162,7 +162,7 @@ url:
     kwargs:
       function: nlg.webapp.render_narrative
       headers:
-        Content-Type: text/plain
+        Content-Type: application/json
         Cache-Control: no-store
   render-live-template-$*:
     pattern: /$YAMLURL/render-live-template

--- a/nlg/app/nlg.js
+++ b/nlg/app/nlg.js
@@ -4,7 +4,68 @@ addCondition, addName, shareNarrative, copyToClipboard,
 findAppliedInflections, checkSelection */
 /* eslint-disable no-global-assign */
 var narrative_name, dataset_name
+var styleparams = {bold: true, italic: false, underline: false, style: 'para'}
 
+function activateStyleControl() {
+  if (styleparams.bold) {
+    $('#boldpreview').addClass('active')
+  }
+  if (styleparams.italic) {
+    $('#italicpreview').addClass('active')
+  }
+  if (styleparams.underline) {
+    $('#ulinepreview').addClass('active')
+  }
+
+  if (styleparams.style == 'para') {
+    $('#parastyle').prop('checked', true)
+  } else {
+    $('#liststyle').prop('checked', true)
+  }
+  renderByStyle()
+}
+
+function toggleRenderStyle(e) {
+  if (e.currentTarget.id == "parastyle") {
+    if ($('#parastyle').prop('checked')) {
+      styleparams.style = "para"
+    }
+  } else if (e.currentTarget.id == "liststyle") {
+    if ($('#liststyle').prop('checked')) {
+      styleparams.style = "list"
+    }
+  } else if (e.currentTarget.id == "boldpreview") {
+    if ($('#boldpreview').hasClass('active')) {
+      styleparams.bold = true
+    } else {
+      styleparams.bold = false
+    }
+  } else if (e.currentTarget.id == "italicpreview") {
+    if ($('#italicpreview').hasClass('active')) {
+      styleparams.italic = true
+    } else {
+      styleparams.italic = false
+    }
+  } else if (e.currentTarget.id == "ulinepreview") {
+    if ($('#ulinepreview').hasClass('active')) {
+      styleparams.underline = true
+    } else {
+      styleparams.underline = false
+    }
+  }
+  renderByStyle()
+}
+
+function renderByStyle() {
+  let url = g1.url.parse(`${nlg_base}/renderall`)
+  url.update(styleparams)
+  $.getJSON(url.toString()).done(
+    (e) => {
+      $(`#previewspan`).html(e.render)
+      styleparams = e.style
+    }
+  )
+}
 
 function makeControlDroppable(elem, ondrop) {
   elem.on('dragover', (e) => {
@@ -180,14 +241,12 @@ function renderPreview(fh) {
 
     // Add the preview
     $.get(`${nlg_base}/render-template/${i}`).done(
-      (e) => {$(`#preview-${i}`).text(e)}
+      (e) => {$(`#preview-${i}`).html(e)}
     )
     // prep the row for dragging
     prepDrag($(`#controlrow-${i}`))
   }
-  $.get(`${nlg_base}/renderall`).done(
-    (e) => {$(`#previewspan`).text(e)}
-  )
+  renderByStyle()
 }
 
 
@@ -243,8 +302,10 @@ function editTemplate(n) {
 function setInitialConfig() {
   // At page ready, load the latest config for the authenticated user
   // and show it.
-  $.get(`${nlg_base}/initconf`).done((e) => {
+  $.getJSON(`${nlg_base}/initconf`).done((e) => {
     refreshTemplates()
+    Object.assign(styleparams, e.style)
+    activateStyleControl()
   })
 }
 


### PR DESCRIPTION
Allows templatized tokens to be rendered in bold, italics, underlines.
Nuggets can be displayed as paragraphs or lists. See #28